### PR TITLE
HealthController should initially be Not Healthy

### DIFF
--- a/notat-api/src/main/kotlin/com/computas/devops101/notatapi/HealthController.kt
+++ b/notat-api/src/main/kotlin/com/computas/devops101/notatapi/HealthController.kt
@@ -9,6 +9,6 @@ import org.springframework.web.bind.annotation.RestController
 class HealthController {
 
     @GetMapping
-    fun getHealthz(): String = "Healthy"
+    fun getHealthz(): String = "Not Healthy"
 
 }


### PR DESCRIPTION
As far as I can tell, we would like the HealthController to be "Not Healthy", since the build should fail for the workshop participants initially. Not really sure if we would like to have this only on the main-branch, or if there's a more suitable branch to put this on :thinking: